### PR TITLE
fix: error when have 'imenu-list but don't have evil.

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,12 @@
+# These are supported funding model platforms
+
+github:  # dalanicolai
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: dalanicolai
+issuehunt: # Replace with a single IssueHunt username
+otechie: # Replace with a single Otechie username
+custom: "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=6BHLS7H9ARJXE&source=url"

--- a/doc-scroll.el
+++ b/doc-scroll.el
@@ -425,11 +425,14 @@ Setf-able function."
     "i" 'doc-scroll-info
     "y" 'doc-scroll-kill-new
     "o" 'imenu-list-smart-toggle
-    [down-mouse-1] 'doc-scroll-select-region))
+    [down-mouse-1] 'doc-scroll-select-region)
+  
+  (when (featurep 'imenu-list)
+    (evil-define-key 'motion imenu-list-major-mode-map
+      "o" 'imenu-list-smart-toggle))
+  )
 
-(when (featurep 'imenu-list)
-  (evil-define-key 'motion imenu-list-major-mode-map
-    "o" 'imenu-list-smart-toggle))
+
 
 (define-minor-mode doc-scroll-minor-mode
   "DS"
@@ -547,7 +550,7 @@ Setf-able function."
                     ;; (point))))
                     (point)
                     (progn (insert (make-string doc-scroll-line-length (string-to-char " ")))
-                      (point)))))
+                           (point)))))
             (insert "\n")
             (overlay-put o 'page  (1+ i))
             (overlay-put o 'window win)
@@ -917,7 +920,7 @@ columns"
                                         ,page
                                         (pointer arrow)))
                                      (when (eq major-mode 'doc-scroll-epdf-mode)
-				       (pdf-links-hotspots-function page image-size))))))
+				                       (pdf-links-hotspots-function page image-size))))))
     ;; (image-flush image)
     (when (= (doc-scroll-columns) 1)
       (overlay-put (doc-scroll-overlay page) 'before-string


### PR DESCRIPTION
There is an error when I have 'imenu-list but not have evil.

It will throw error: there are not 'evil-define-key.

So I put imenu-list to "(when (featurep 'evil)" inner.